### PR TITLE
Use classnames' bind with CSS modules

### DIFF
--- a/client/components/hello/index.js
+++ b/client/components/hello/index.js
@@ -3,11 +3,14 @@
 // ==================================================
 
 import React from 'react';
-import { wrap, heading } from './style.css';
+import classnames from 'classnames';
+import style from './style.css';
+
+const cx = classnames.bind(style);
 
 const Hello = () => (
-  <div className={wrap}>
-    <h1 className={heading}>Hello React</h1>
+  <div className={cx('wrap')}>
+    <h1 className={cx('heading')}>Hello React</h1>
     <div>🙈</div>
   </div>
 );

--- a/client/components/hello/style.css
+++ b/client/components/hello/style.css
@@ -8,6 +8,7 @@
   line-height: 2;
   cursor: default;
 }
+
 .heading:hover {
   font-weight: bold;
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-preset-es2015": "^6.13.2",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
+    "classnames": "^2.2.5",
     "cross-env": "^2.0.0",
     "css-loader": "^0.23.1",
     "eslint": "^3.3.1",


### PR DESCRIPTION
### What's [classnames](https://github.com/JedWatson/classnames) library ?

A simple javascript utility for conditionally joining classNames together.

Example from classnames github:

``` js
var classNames = require('classnames');
classNames('foo', 'bar'); // => 'foo bar'
```
### What's classnames' bind ?

[Alternate bind version (for css-modules)](https://github.com/JedWatson/classnames#alternate-bind-version-for-css-modules)

Example from classnames github:

``` js
var classNames = require('classnames/bind');

var styles = {
  foo: 'abc',
  bar: 'def',
  baz: 'xyz'
};

var cx = classNames.bind(styles);

var className = cx('foo', ['bar'], { baz: true }); // => "abc def xyz"
```
