### PR TITLE
Removed deprecated method .development()

### DIFF
--- a/tools/build_static_entry.js
+++ b/tools/build_static_entry.js
@@ -8,7 +8,6 @@ const projectBasePath = path.resolve(__dirname, '..');
 // run the build_static script with Wepback's require() like behaviour
 // when requiring images etc.
 const webpackIsomorphicTools = new WebpackIsomorphicTools(isomorphicConfig)
-  .development(false)
   .server(projectBasePath, () => {
     const { javascript, styles } = webpackIsomorphicTools.assets();
 


### PR DESCRIPTION
[webpack-isomorphic-tools] [error] .development() method is now deprecated (for server-side instance only, not for webpack plugin instance) and has no effect. Set up a proper process.env.NODE_ENV variable instead: it should be "production" for production, otherwise it assumes development. The currently used mode is: production. `process.env.NODE_ENV is: production 

Fixed the above error while running npm run build:static